### PR TITLE
TW-1037 Fix bug: cannot open deeplink in the android API 32 and above

### DIFF
--- a/lib/t_chain_payment_sdk.dart
+++ b/lib/t_chain_payment_sdk.dart
@@ -95,15 +95,18 @@ class TChainPaymentSDK {
       queryParameters: params,
     );
 
-    final result = await canLaunchUrl(uri);
+    bool result = false;
+    try {
+      result = await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (e) {
+      debugPrint(e.toString());
+    }
 
     if (result == false) {
       launchUrlString(env.downloadUrl);
 
       return TChainPaymentResult(status: TChainPaymentStatus.failed);
     }
-
-    launchUrl(uri, mode: LaunchMode.externalApplication);
 
     return TChainPaymentResult(status: TChainPaymentStatus.waiting);
   }


### PR DESCRIPTION
`Starting in Android 12 (API level 31), you can [manually verify](https://developer.android.com/training/app-links/verify-site-associations#manual-verification) how the system resolves your Android App Links.`
Ref: https://developer.android.com/training/app-links/verify-site-associations

In practice, I cannot verify the deep link by using `android:autoVerify="true"`. It always returns false.
But, as I see we may ignore the verification condition by calling `launchUrl(...)` function directly.
- If the app can launch Url, we will do the flow as normal
- if the app cannot launch Url, it means My T-Wallet hasn't been installed yet, and we will navigate to the store to download it


